### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(object_recognition_msgs)
 
 # generate the messages and the actionlib server for ROS


### PR DESCRIPTION
Switch to cmake minimum v3.5 . Compatibility with versions of CMake older than 3.5 is now deprecated in cmake 3.27